### PR TITLE
feat: do not include dependencies in bundle

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -3,7 +3,8 @@ import dts from 'bun-plugin-dts'
 
 const defaultBuildConfig: BuildConfig = {
   entrypoints: ['./src/index.ts'],
-  outdir: './dist'
+  outdir: './dist',
+  packages: 'external',
 }
 
 await Promise.all([


### PR DESCRIPTION
Bun bundles all dependencies by default.
When creating a library, you rarily need to bundle all dependencies and would rather have them propagated through dependencies.

For my library this changed my output from ~27000 lines to ~400